### PR TITLE
Remove console output when GattCharacteristic gets disposed or finalized

### DIFF
--- a/src/GattCharacteristic.cs
+++ b/src/GattCharacteristic.cs
@@ -31,7 +31,6 @@ namespace HashtagChris.DotNetBlueZ
 
     public void Dispose()
     {
-      Console.WriteLine("GattCharacteristic disposing.");
       m_propertyWatcher?.Dispose();
       m_propertyWatcher = null;
 


### PR DESCRIPTION
this can be quite spammy for an application that queries a lot of characteristics...