### PR TITLE
Upgrade to Tmds.DBus 0.14.0

### DIFF
--- a/src/DotNetBlueZ.csproj
+++ b/src/DotNetBlueZ.csproj
@@ -8,7 +8,7 @@
   <!-- NuGet -->
   <PropertyGroup>
     <PackageId>HashtagChris.DotNetBlueZ</PackageId>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Authors>Chris Sidi</Authors>
     <Title>Quick and dirty library for BlueZ's D-Bus APIs</Title>
     <Description>A quick and dirty library for BlueZ's D-Bus APIs. Focus is on Bluetooth Low Energy APIs.</Description>
@@ -19,8 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tmds.DBus" Version="0.7.0" />
-    <DotNetCliToolReference Include="Tmds.DBus.Tool" Version="0.7.0" />
+    <PackageReference Include="Tmds.DBus" Version="0.14.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgraded Tmds.DBus to the latest (0.14.0) as of this PR.

Using this library on a Raspberry Pi 4B with .NET Core 6 and I am able to get the discovery application working.

I had to drop the Tmds.DBus.Tool as that did not appear to allow `dotnet build` to work (was complaining about a missing library?).